### PR TITLE
[FEAT] #63 - 일일 낫투두 조회 API 연결

### DIFF
--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		3BFE840B29704534000B37CA /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 3BFE840A29704534000B37CA /* Kingfisher */; };
 		3BFE840D2970454E000B37CA /* NetworkBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE840C2970454E000B37CA /* NetworkBase.swift */; };
 		3BFE840F297045D4000B37CA /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE840E297045D4000B37CA /* UIImageView+.swift */; };
+		3BFE8411297059D7000B37CA /* DailyMissionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */; };
 		6C600BC029693B3100421D7A /* MissionHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BBF29693B3100421D7A /* MissionHistoryModel.swift */; };
 		6C600BC229693B3B00421D7A /* MissionHistoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BC129693B3B00421D7A /* MissionHistoryCollectionViewCell.swift */; };
 		6C600BC429693B4B00421D7A /* MissionHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BC329693B4B00421D7A /* MissionHistoryViewController.swift */; };
@@ -241,6 +242,7 @@
 		3BFE8404296FD103000B37CA /* CheckboxToolTipViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxToolTipViewController.swift; sourceTree = "<group>"; };
 		3BFE840C2970454E000B37CA /* NetworkBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBase.swift; sourceTree = "<group>"; };
 		3BFE840E297045D4000B37CA /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMissionResponseDTO.swift; sourceTree = "<group>"; };
 		6C600BBF29693B3100421D7A /* MissionHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryModel.swift; sourceTree = "<group>"; };
 		6C600BC129693B3B00421D7A /* MissionHistoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		6C600BC329693B4B00421D7A /* MissionHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryViewController.swift; sourceTree = "<group>"; };
@@ -815,6 +817,7 @@
 			isa = PBXGroup;
 			children = (
 				3B90A431296F2981000D6852 /* BannerResponseDTO.swift */,
+				3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1136,6 +1139,7 @@
 				096BE0192966A18A009ED396 /* CustomPaddingLabel.swift in Sources */,
 				6CA2EFB9296FD0D400D3E66B /* AddSituationResponseDTO.swift in Sources */,
 				3B5ED42C2961DC310052D2B8 /* HomeView.swift in Sources */,
+				3BFE8411297059D7000B37CA /* DailyMissionResponseDTO.swift in Sources */,
 				3BE07002296F43A2002CC50A /* UIButton+.swift in Sources */,
 				6C600BC429693B4B00421D7A /* MissionHistoryViewController.swift in Sources */,
 				099F073D296C2F770036CF55 /* CustomSegmentedControl.swift in Sources */,

--- a/NotToDo/NotToDo/Network/API/Achieve/MissionStatisticsAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Achieve/MissionStatisticsAPI.swift
@@ -21,7 +21,7 @@ final class MissionStatisticsAPI {
     
     // MARK: - GET
     
-    func getMissionStatistics(completion: @escaping (GeneralArrayResponse<MissionStatistcsResponse>?) -> ()) {
+    func getMissionStatistics(completion: @escaping (GeneralArrayResponse<MissionStatistcsResponse>?) -> Void) {
         missionStatisticsProvider.request(.missionStatistics) { result in
             switch result {
             case .success(let response):

--- a/NotToDo/NotToDo/Network/API/Achieve/SituationStatisticsAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Achieve/SituationStatisticsAPI.swift
@@ -21,7 +21,7 @@ final class SituationStatisticsAPI {
     
     // MARK: - GET
     
-    func getSituationStatistics(completion: @escaping (GeneralArrayResponse<SituationStatistcsResponse>?) -> ()) {
+    func getSituationStatistics(completion: @escaping (GeneralArrayResponse<SituationStatistcsResponse>?) -> Void) {
         situationStatisticsProvider.request(.situationStatistics) { result in
             switch result {
             case .success(let response):

--- a/NotToDo/NotToDo/Network/API/AddSituation/AddSituationAPI.swift
+++ b/NotToDo/NotToDo/Network/API/AddSituation/AddSituationAPI.swift
@@ -20,7 +20,7 @@ final class AddSituationAPI {
     
     // MARK: - GET
     
-    func getAddSituation(completion: @escaping (GeneralResponse<AddSituationResponse>?) -> ()) {
+    func getAddSituation(completion: @escaping (GeneralResponse<AddSituationResponse>?) -> Void) {
         addSituationProvider.request(.addSituation) { result in
             switch result {
             case .success(let response):

--- a/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
@@ -15,6 +15,8 @@ final class HomeAPI {
     var homeProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggingPlugin()])
     
     private init() { }
+    
+    public private(set) var missionDailyData: GeneralArrayResponse<DailyMissionResponseDTO>?
 
     // MARK: - GET
         
@@ -25,6 +27,20 @@ final class HomeAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = NetworkBase.judgeStatus(by: statusCode, data, BannerResponse.self)
+                completion(networkResult)
+            case let .failure(err):
+                print(err)
+            }
+        }
+    }
+    
+    func getDailyMission(date: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        homeProvider.request(.dailyMission(date: date)) { response in
+            switch response {
+            case let .success(response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = NetworkBase.judgeStatus(by: statusCode, data, [DailyMissionResponseDTO].self)
                 completion(networkResult)
             case let .failure(err):
                 print(err)

--- a/NotToDo/NotToDo/Network/API/Recommend/RecommendAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Recommend/RecommendAPI.swift
@@ -21,7 +21,7 @@ final class RecommendAPI {
     
     // MARK: - GET
     
-    func getRecommend(index: Int, completion: @escaping (GeneralArrayResponse<RecommendElementResponse>?) -> ()) {
+    func getRecommend(index: Int, completion: @escaping (GeneralArrayResponse<RecommendElementResponse>?) -> Void) {
         recommendProvider.request(.recommendEnvirionment(id: index )) { result in
             switch result {
             case .success(let response):

--- a/NotToDo/NotToDo/Network/Base/URLConstant.swift
+++ b/NotToDo/NotToDo/Network/Base/URLConstant.swift
@@ -16,6 +16,7 @@ struct URLConstant {
     // MARK: - Home
     
     static let homeBanner = "/banner"
+    static let dailyMission = "/mission/daily"
     
     // MARK: - Recommend
     
@@ -25,5 +26,8 @@ struct URLConstant {
     
     static let situationStatistics = "/mission/stat/situation"
     static let missionStatistics = "/mission/stat/notTodo"
+
+    // MARK: - AddMission
+    
     static let addSituation = "/situation"
 }

--- a/NotToDo/NotToDo/Network/DataModel/Home/DailyMissionResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/DailyMissionResponseDTO.swift
@@ -1,0 +1,19 @@
+//
+//  DailyMissionResponseDTO.swift
+//  NotToDo
+//
+//  Created by 강윤서 on 2023/01/13.
+//
+
+import Foundation
+import UIKit
+
+struct DailyMissionResponseDTO: Codable {
+    let id: Int
+    let title, situation, completionStatus, goal: String
+    let actions: [ActionDTO]
+}
+
+struct ActionDTO: Codable {
+    let name: String
+}

--- a/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
+++ b/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
@@ -11,6 +11,7 @@ import Moya
 
 enum HomeService {
     case banner
+    case dailyMission(date: String)
 }
 
 extension HomeService: TargetType {
@@ -22,26 +23,28 @@ extension HomeService: TargetType {
         switch self {
         case .banner:
             return URLConstant.homeBanner
+        case .dailyMission(let date):
+            return URLConstant.dailyMission + "/\(date)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .banner:
+        case .banner, .dailyMission:
             return .get
         }
     }
     
     var task: Moya.Task {
         switch self {
-        case .banner:
+        case .banner, .dailyMission:
             return .requestPlain
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .banner:
+        case .banner, .dailyMission:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeMissionCollectionViewCell.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeMissionCollectionViewCell.swift
@@ -209,11 +209,11 @@ extension HomeMissionCollectionViewCell {
         }
     }
     
-    func configure(_ model: DailyMission) {
+    func configure(_ model: DailyMissionResponseDTO) {
         situationLabel.text = model.situation
         missionTitleLabel.text = model.title
         goalTitleLabel.text = model.goal
-        setAction(model.actions)
+        setAction(model.actions.map { $0.name })
     }
     
     private func setAction(_ actionList: [String]) {

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -39,7 +39,7 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         requestBannerAPI()
-        requestDailyMissionDTO(date: "2023-01-23")
+        requestDailyMissionDTO(date: "2023-01-24")
     }
     
 }
@@ -79,7 +79,7 @@ extension HomeViewController {
     }
     
     private func requestDailyMissionDTO(date: String) {
-        HomeAPI.shared.getDailyMission(date: "2023-01-23") { [weak self] result in
+        HomeAPI.shared.getDailyMission(date: "2023-01-24") { [weak self] result in
             switch result {
             case let .success(data):
                 guard let data = data as? [DailyMissionResponseDTO] else { return }
@@ -110,7 +110,7 @@ extension HomeViewController {
     @objc func handleRefreshControl() {
         // 컨텐츠를 업데이트하세요.
         requestBannerAPI()
-        requestDailyMissionDTO(date: "2023-01-23")
+        requestDailyMissionDTO(date: "2023-01-24")
         homeView.homeCollectionView.reloadData()
         
         // Refresh control을 제거하세요.
@@ -203,11 +203,10 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let cellHeight = 144.adjusted
-        print(indexPath.row, "😃")
-//        if let missionList = missionList {
-//            let cellHeight = missionList[indexPath.row].actions.count < 2 ? 144.adjusted : 183.adjusted
-//        }
+        var cellHeight = 144.adjusted
+        if !missionList.isEmpty {
+            cellHeight = missionList[indexPath.row].actions.count < 2 ? 144.adjusted : 183.adjusted
+        }
         switch indexPath.section {
         case 0:
             return CGSize(width: Numbers.width, height: 106.adjusted)

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -14,7 +14,7 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
     
     // MARK: - Properties
     
-    var missionList: [DailyMission] = DailyMission.DailyMissionModel
+    var missionList: [DailyMissionResponseDTO] = []
     var banner: BannerResponse?
     
     // MARK: - UI Components
@@ -39,6 +39,7 @@ final class HomeViewController: UIViewController, UICollectionViewDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         requestBannerAPI()
+        requestDailyMissionDTO(date: "2023-01-23")
     }
     
 }
@@ -75,7 +76,25 @@ extension HomeViewController {
                 print("networkFail")
             }
         }
-        
+    }
+    
+    private func requestDailyMissionDTO(date: String) {
+        HomeAPI.shared.getDailyMission(date: "2023-01-23") { [weak self] result in
+            switch result {
+            case let .success(data):
+                guard let data = data as? [DailyMissionResponseDTO] else { return }
+                self?.missionList = data
+                self?.homeView.homeCollectionView.reloadData()
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkFail")
+            case .requestErr(_):
+                print("networkFail")
+            }
+        }
     }
     
     // MARK: - @objc Methods
@@ -91,6 +110,7 @@ extension HomeViewController {
     @objc func handleRefreshControl() {
         // 컨텐츠를 업데이트하세요.
         requestBannerAPI()
+        requestDailyMissionDTO(date: "2023-01-23")
         homeView.homeCollectionView.reloadData()
         
         // Refresh control을 제거하세요.
@@ -149,7 +169,11 @@ extension HomeViewController: UICollectionViewDataSource {
         case 0:
             return 1
         default:
-            return missionList.count
+            if missionList.isEmpty {
+                return 1
+            } else {
+                return missionList.count ?? 1
+            }
         }
     }
     
@@ -179,12 +203,16 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let cellHeight = missionList[indexPath.row].actions.count < 2 ? 144.adjusted : 183.adjusted
+        let cellHeight = 144.adjusted
+        print(indexPath.row, "😃")
+//        if let missionList = missionList {
+//            let cellHeight = missionList[indexPath.row].actions.count < 2 ? 144.adjusted : 183.adjusted
+//        }
         switch indexPath.section {
         case 0:
             return CGSize(width: Numbers.width, height: 106.adjusted)
         default:
-            if missionList.isEmpty {
+            if missionList.count == 0 {
                 return CGSize(width: Numbers.width, height: (collectionView.frame.height - 105).adjusted)            // 수정 필요
             } else {
                 return CGSize(width: Numbers.width, height: cellHeight)

--- a/NotToDo/NotToDo/Presentation/MissionHistoryScene/Views/MissionHistoryView.swift
+++ b/NotToDo/NotToDo/Presentation/MissionHistoryScene/Views/MissionHistoryView.swift
@@ -195,9 +195,3 @@ extension MissionHistoryView: UICollectionViewDelegate {
         inputTextField.text = historyList[indexPath.row].history
     }
 }
-
-//extension MissionHistoryView: UITextFieldDelegate {
-//    func textFieldDidEndEditing(_ textField: UITextField) {
-//        delegate?.sendMissionHistoryTextFieldData(text: self.inputTextField.text ?? "")
-//    }
-//}


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 일일 낫투두 조회 API 연결

## 👻 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 캘린더 날짜 클릭 시 데이터 전달 구현 전이라 더미 값으로 넣어두었습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|     일일 낫투두 조회 API 연결     |<img src = "https://user-images.githubusercontent.com/65678579/212123306-f3246978-26e8-4d30-bbf9-33636979a56f.png" width ="375">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #63
