### PR TITLE
[FEAT] #68 - 낫투두 완료여부 변경 API 연결

### DIFF
--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		3BFE840D2970454E000B37CA /* NetworkBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE840C2970454E000B37CA /* NetworkBase.swift */; };
 		3BFE840F297045D4000B37CA /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE840E297045D4000B37CA /* UIImageView+.swift */; };
 		3BFE8411297059D7000B37CA /* DailyMissionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */; };
+		3BFE8413297071BB000B37CA /* UpdateMissionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE8412297071BB000B37CA /* UpdateMissionResponseDTO.swift */; };
 		6C600BC029693B3100421D7A /* MissionHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BBF29693B3100421D7A /* MissionHistoryModel.swift */; };
 		6C600BC229693B3B00421D7A /* MissionHistoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BC129693B3B00421D7A /* MissionHistoryCollectionViewCell.swift */; };
 		6C600BC429693B4B00421D7A /* MissionHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C600BC329693B4B00421D7A /* MissionHistoryViewController.swift */; };
@@ -245,6 +246,7 @@
 		3BFE840C2970454E000B37CA /* NetworkBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBase.swift; sourceTree = "<group>"; };
 		3BFE840E297045D4000B37CA /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMissionResponseDTO.swift; sourceTree = "<group>"; };
+		3BFE8412297071BB000B37CA /* UpdateMissionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateMissionResponseDTO.swift; sourceTree = "<group>"; };
 		6C600BBF29693B3100421D7A /* MissionHistoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryModel.swift; sourceTree = "<group>"; };
 		6C600BC129693B3B00421D7A /* MissionHistoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		6C600BC329693B4B00421D7A /* MissionHistoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryViewController.swift; sourceTree = "<group>"; };
@@ -822,6 +824,7 @@
 			children = (
 				3B90A431296F2981000D6852 /* BannerResponseDTO.swift */,
 				3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */,
+				3BFE8412297071BB000B37CA /* UpdateMissionResponseDTO.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1224,6 +1227,7 @@
 				3B59AFB8296346650050FF49 /* Numbers.swift in Sources */,
 				6CDC2D212966C86D00BFF5F4 /* AddMissionTextField.swift in Sources */,
 				6CA2EFBB296FD16800D3E66B /* AddSituationAPI.swift in Sources */,
+				3BFE8413297071BB000B37CA /* UpdateMissionResponseDTO.swift in Sources */,
 				3BE07012296F4454002CC50A /* NetworkConstant.swift in Sources */,
 				3BE07018296F44E8002CC50A /* AchievementViewController.swift in Sources */,
 				3BE0700D296F43A2002CC50A /* UIViewController+.swift in Sources */,

--- a/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
@@ -17,6 +17,7 @@ final class HomeAPI {
     private init() { }
     
     public private(set) var missionDailyData: GeneralArrayResponse<DailyMissionResponseDTO>?
+    public private(set) var updateMissionStatus: GeneralResponse<UpdateMissionResponseDTO>?
 
     // MARK: - GET
         
@@ -26,7 +27,7 @@ final class HomeAPI {
             case let .success(response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = NetworkBase.judgeStatus(by: statusCode, data, BannerResponse.self)
+                let networkResult = NetworkBase.judgeStatus(by: statusCode, data, BannerResponseDTO.self)
                 completion(networkResult)
             case let .failure(err):
                 print(err)
@@ -47,4 +48,25 @@ final class HomeAPI {
             }
         }
     }
+    
+    // MARK: - Patch
+    
+    func patchUpdateMissionStatus(id: Int, status: String, completion: @escaping (GeneralResponse<UpdateMissionResponseDTO>?) -> Void) {
+        homeProvider.request(.updateMissionStatus(id: id, status: status)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.updateMissionStatus = try response.map(GeneralResponse<UpdateMissionResponseDTO>?.self)
+                    guard let updateMissionStatus = self.updateMissionStatus else { return }
+                    completion(self.updateMissionStatus)
+                } catch (let err) {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+
 }

--- a/NotToDo/NotToDo/Network/Base/URLConstant.swift
+++ b/NotToDo/NotToDo/Network/Base/URLConstant.swift
@@ -17,6 +17,7 @@ struct URLConstant {
     
     static let homeBanner = "/banner"
     static let dailyMission = "/mission/daily"
+    static let updateMissionStatus = "/mission"
     
     // MARK: - Recommend
     

--- a/NotToDo/NotToDo/Network/DataModel/Home/BannerResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/BannerResponseDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct BannerResponse: Codable {
+struct BannerResponseDTO: Codable {
     let title: String
     let image: String
 }

--- a/NotToDo/NotToDo/Network/DataModel/Home/DailyMissionResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/DailyMissionResponseDTO.swift
@@ -10,7 +10,7 @@ import UIKit
 
 struct DailyMissionResponseDTO: Codable {
     let id: Int
-    let title, situation, completionStatus, goal: String
+    var title, situation, completionStatus, goal: String
     let actions: [ActionDTO]
 }
 

--- a/NotToDo/NotToDo/Network/DataModel/Home/UpdateMissionResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/UpdateMissionResponseDTO.swift
@@ -1,0 +1,13 @@
+//
+//  UpdateMissionResponseDTO.swift
+//  NotToDo
+//
+//  Created by 강윤서 on 2023/01/13.
+//
+
+import Foundation
+
+struct UpdateMissionResponseDTO: Codable {
+    let id: Int
+    let completionStatus: String
+}

--- a/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
+++ b/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
@@ -12,6 +12,7 @@ import Moya
 enum HomeService {
     case banner
     case dailyMission(date: String)
+    case updateMissionStatus(id: Int, status: String)
 }
 
 extension HomeService: TargetType {
@@ -25,6 +26,8 @@ extension HomeService: TargetType {
             return URLConstant.homeBanner
         case .dailyMission(let date):
             return URLConstant.dailyMission + "/\(date)"
+        case .updateMissionStatus(let id, _):
+            return URLConstant.updateMissionStatus + "/\(id)" + "/check"
         }
     }
     
@@ -32,6 +35,8 @@ extension HomeService: TargetType {
         switch self {
         case .banner, .dailyMission:
             return .get
+        case .updateMissionStatus:
+            return .patch
         }
     }
     
@@ -39,12 +44,15 @@ extension HomeService: TargetType {
         switch self {
         case .banner, .dailyMission:
             return .requestPlain
+        case .updateMissionStatus(_, let status):
+            return .requestParameters(parameters: ["completionStatus": status],
+                                      encoding: JSONEncoding.default)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .banner, .dailyMission:
+        case .banner, .dailyMission, .updateMissionStatus:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeCollectionReusableView.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeCollectionReusableView.swift
@@ -94,7 +94,7 @@ extension HomeCollectionReusableView {
         }
     }
     
-    func setRandomData(banner: BannerResponse) {
+    func setRandomData(banner: BannerResponseDTO) {
         graphicImageView.setImage(with: banner.image)
         let randomText = banner.title
         motivationLabel.text = randomText

--- a/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeMissionCollectionViewCell.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeMissionCollectionViewCell.swift
@@ -16,8 +16,10 @@ final class HomeMissionCollectionViewCell: UICollectionViewCell {
     
     static let identifier = "HomeMissionCollectionViewCell"
     var selectStatusButton: Bool? = true
-    var clickedStatusButton: (() -> Void)?
-    var meatballClickedEvent: ((Bool) -> Void)?
+    var clickedStatusButton: ((Int) -> Void)?
+    var meatballClickedEvent: (() -> Void)?
+    var missionId: Int?
+    var indexPath: IndexPath?
     
     // MARK: - UI Components
     
@@ -214,6 +216,17 @@ extension HomeMissionCollectionViewCell {
         missionTitleLabel.text = model.title
         goalTitleLabel.text = model.goal
         setAction(model.actions.map { $0.name })
+        missionId = model.id
+        
+        if model.completionStatus == "FINISH" {
+            statusButton.setImage(.checkCircle , for: .normal)
+        } else if (model.completionStatus == "AMBIGUOUS") {
+            statusButton.setImage(.checkTriangle , for: .normal)
+        }
+        else {
+            statusButton.setImage(.checkDefault, for: .normal)
+        }
+        
     }
     
     private func setAction(_ actionList: [String]) {
@@ -234,10 +247,12 @@ extension HomeMissionCollectionViewCell {
     }
     
     @objc func statusButtonTapped(_ sender: UIButton) {
-        clickedStatusButton?()
+        guard let missionId = missionId else { return }
+        clickedStatusButton?(missionId)
     }
     
     @objc func meatballButtonTapped(_ sender: UIView) {
-        meatballClickedEvent?(true)
+        guard let missionId = missionId else { return }
+        meatballClickedEvent?()
     }
 }

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/CheckboxToolTipViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/CheckboxToolTipViewController.swift
@@ -10,7 +10,17 @@ import UIKit
 import SnapKit
 import Then
 
+protocol CheckboxToolTipDelegate: AnyObject {
+    func setMissionStatus(status: String, indexPath: IndexPath)
+}
+
 final class CheckboxToolTipViewController: UIViewController {
+    
+    // MARK: - Properties
+    
+    var id: Int = 0
+    weak var delegate: CheckboxToolTipDelegate?
+    var indexPath: IndexPath?
     
     // MARK: - UI Components
     
@@ -23,7 +33,6 @@ final class CheckboxToolTipViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-       
         setUI()
         setLayout()
         addTapGesture()
@@ -74,12 +83,26 @@ extension CheckboxToolTipViewController {
         missionAmbiguousButton.addTarget(self, action: #selector(ambiguousMission), for: .touchUpInside)
     }
     
+    private func requestPatchUpdateMissionAPI(id: Int, status: String) {
+        HomeAPI.shared.patchUpdateMissionStatus(id: id, status: status) { [weak self] result in
+            guard let self = self else { return }
+            guard let response = result else { return }
+            
+        }
+    }
+    
     @objc private func successMission(_ sender: UIButton) {
-        print("성공")
+        requestPatchUpdateMissionAPI(id: self.id, status: "FINISH")
+        guard let indexPath = indexPath else { return }
+        delegate?.setMissionStatus(status: "FINISH", indexPath: indexPath)
+        self.dismiss(animated: true)
     }
     
     @objc private func ambiguousMission(_ sender: UIButton) {
-        print("애매")
+        requestPatchUpdateMissionAPI(id: self.id, status: "AMBIGUOUS")
+        guard let indexPath = indexPath else { return }
+        delegate?.setMissionStatus(status: "AMBIGUOUS", indexPath: indexPath)
+        self.dismiss(animated: true)
     }
     
     @objc private func dismissViewController() {


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 낫투두 완료여부 변경 API 연결
- 변경 여부에 따른 UI 업데이트


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->


|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|     낫투두 완료여부 변경 API 연결       |<img src = "https://user-images.githubusercontent.com/65678579/212154719-23095a2d-a1ea-4295-be68-9be0a53b026b.gif" width ="375">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #68
