### PR TITLE
[FIX]  #66 - 성취뷰 오류 수정, 추천뷰 플로우 수정

### DIFF
--- a/NotToDo/NotToDo/Presentation/AchievementScene/ViewControllers/AchievementViewController.swift
+++ b/NotToDo/NotToDo/Presentation/AchievementScene/ViewControllers/AchievementViewController.swift
@@ -71,9 +71,9 @@ extension AchievementViewController {
             $0.text = I18N.statistcisBottomMessage
             $0.font = .PretendardMedium(size: 12.adjusted)
             $0.textColor = .nottodoGray2
-            if missionView.missionList.isEmpty && situationView.situationList.isEmpty {
-                $0.isHidden = true
-            }
+//            if missionView.missionList.isEmpty && situationView.situationList.isEmpty {
+//                $0.isHidden = true
+//            }
         }
     }
     
@@ -83,7 +83,9 @@ extension AchievementViewController {
             guard let response = response else { return }
             self?.missionList = response.data!
             self?.configMissionView()
+            self?.missionView.setUI()
             self?.missionView.missionTableView.reloadData()
+            self?.relayout()
             dump(response)
         }
         SituationStatisticsAPI.shared.getSituationStatistics { [weak self] response in
@@ -91,7 +93,9 @@ extension AchievementViewController {
             guard let response = response else { return }
             self?.situationList = response.data!
             self?.configSituationView()
+            self?.situationView.setUI()
             self?.situationView.expangindTableView.reloadData()
+            self?.relayout()
             print(response)
             dump(response)
         }
@@ -140,9 +144,9 @@ extension AchievementViewController {
             if missionView.missionList.isEmpty {
                 $0.height.equalTo(300.adjusted)
             } else {
-                $0.height.equalTo(CGFloat(missionView.missionList.count) * 55.adjusted + 92.adjusted)
+                $0.height.equalTo(CGFloat(missionView.missionList.count) * 55.adjusted + 105.adjusted)
             }
-            $0.bottom.equalTo(scrollView.snp.bottom).offset(-78.adjusted)
+            $0.bottom.lessThanOrEqualTo(scrollView.snp.bottom).offset(-78.adjusted)
         }
         
         situationView.snp.makeConstraints {
@@ -151,15 +155,16 @@ extension AchievementViewController {
             if situationView.situationList.isEmpty {
                 $0.height.equalTo(300.adjusted)
             } else {
-                $0.height.equalTo(CGFloat(situationView.situationList.count) * 55.adjusted + 120.adjusted)
+                $0.height.equalTo(CGFloat(situationView.situationList.count) * 55.adjusted + 105.adjusted)
             }
+            $0.bottom.lessThanOrEqualTo(scrollView.snp.bottom).offset(-78.adjusted)
         }
         bottomLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(20.adjusted)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(20.adjusted)
             if missionView.isHidden {
-                $0.top.equalTo(situationView.snp.top).offset(CGFloat(situationView.situationList.count) * 55.adjusted + 130.adjusted)
+                $0.top.equalTo(situationView.snp.bottom).offset(10.adjusted)
             } else {
-                $0.top.equalTo(missionView.snp.top).offset(CGFloat(missionView.missionList.count) * 55.adjusted + 102.adjusted)
+                $0.top.equalTo(missionView.snp.bottom).offset(10.adjusted)
             }
         }
         segmentedControl.addTarget(self, action: #selector(didChangeValue(segment:)), for: .valueChanged)
@@ -169,12 +174,33 @@ extension AchievementViewController {
     }
     
     func relayout() {
+        missionView.snp.remakeConstraints {
+            $0.directionalHorizontalEdges.equalTo(safeArea).inset(20.adjusted)
+            $0.top.equalTo(segmentedControl.snp.bottom).offset(20.adjusted)
+            if missionView.missionList.isEmpty {
+                $0.height.equalTo(300.adjusted)
+            } else {
+                $0.height.equalTo(CGFloat(missionView.missionList.count) * 55.adjusted + 105.adjusted)
+            }
+            $0.bottom.lessThanOrEqualTo(scrollView.snp.bottom).offset(-78.adjusted)
+        }
+        
+        situationView.snp.remakeConstraints {
+            $0.directionalHorizontalEdges.equalTo(safeArea).inset(20.adjusted)
+            $0.top.equalTo(segmentedControl.snp.bottom).offset(20.adjusted)
+            if situationView.situationList.isEmpty {
+                $0.height.equalTo(300.adjusted)
+            } else {
+                $0.height.equalTo(CGFloat(situationView.situationList.count) * 55.adjusted + 105.adjusted)
+            }
+            $0.bottom.lessThanOrEqualTo(scrollView.snp.bottom).offset(-78.adjusted)
+        }
         bottomLabel.snp.remakeConstraints {
             $0.leading.equalToSuperview().offset(20.adjusted)
             if missionView.isHidden {
-                $0.top.equalTo(situationView.snp.top).offset(CGFloat(situationView.situationList.count) * 55.adjusted + 130.adjusted)
+                $0.top.equalTo(situationView.snp.bottom).offset(10.adjusted)
             } else {
-                $0.top.equalTo(missionView.snp.top).offset(CGFloat(missionView.missionList.count) * 55.adjusted + 102.adjusted)
+                $0.top.equalTo(missionView.snp.bottom).offset(10.adjusted)
             }
         }
     }

--- a/NotToDo/NotToDo/Presentation/AchievementScene/Views/MissionStatisticsView.swift
+++ b/NotToDo/NotToDo/Presentation/AchievementScene/Views/MissionStatisticsView.swift
@@ -25,7 +25,7 @@ class MissionStatisticsView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
-        setUI()
+//        setUI()
         register()
         setLayout()
     }

--- a/NotToDo/NotToDo/Presentation/AchievementScene/Views/SituationStatisticsView.swift
+++ b/NotToDo/NotToDo/Presentation/AchievementScene/Views/SituationStatisticsView.swift
@@ -27,7 +27,7 @@ class SituationStatisticsView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
-        setUI()
+//        setUI()
         register()
         setLayout()
     }
@@ -42,6 +42,7 @@ class SituationStatisticsView: UIView {
 extension SituationStatisticsView {
     func setUI() {
         if situationList.isEmpty {
+            print("situation empty")
             backgroundColor = .clear
             situationTitleView.isHidden = true
             expangindTableView.isScrollEnabled = false

--- a/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
+++ b/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
@@ -65,6 +65,7 @@ extension AddMissionViewController {
     
     @objc private func pushToRecommendViewController() {
         let recommendViewController = RecommendViewController()
+        recommendViewController.navigationBarView = NavigationBarView(frame: CGRect(), mode: .recommend)
         navigationController?.pushViewController(recommendViewController, animated: true)
     }
     

--- a/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
+++ b/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
@@ -22,7 +22,7 @@ final class AddMissionViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private var addMissionView: AddMissionView!
+    var addMissionView: AddMissionView!
     
     // MARK: - View Life Cycle
     

--- a/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
+++ b/NotToDo/NotToDo/Presentation/AddMissionScene/ViewControllers/AddMissionViewController.swift
@@ -18,6 +18,8 @@ final class AddMissionViewController: UIViewController {
         }
     }
     
+    var behavior: String?
+    
     // MARK: - UI Components
     
     private var addMissionView: AddMissionView!
@@ -33,6 +35,9 @@ final class AddMissionViewController: UIViewController {
     override func loadView() {
         super.loadView()
         addMissionView = AddMissionView()
+        if let behavior = behavior {
+            addMissionView.dataBind(behavior: behavior)
+        }
         view = addMissionView
     }
 }

--- a/NotToDo/NotToDo/Presentation/AddMissionScene/Views/AddMissionView.swift
+++ b/NotToDo/NotToDo/Presentation/AddMissionScene/Views/AddMissionView.swift
@@ -326,6 +326,10 @@ extension AddMissionView {
         dateButton.setTitle(date, for: .normal)
     }
     
+    func dataBind(behavior: String) {
+        behaviorTextField.text = behavior
+    }
+    
     // MARK: - @objc Methods
     
     func availableAddMission(_ enable: Bool) {

--- a/NotToDo/NotToDo/Presentation/RecommendScene/Cell/RecommendCollectionViewCell.swift
+++ b/NotToDo/NotToDo/Presentation/RecommendScene/Cell/RecommendCollectionViewCell.swift
@@ -16,6 +16,9 @@ class RecommendCollectionViewCell: UICollectionViewCell {
     
     static var identifier = "RecommendCollectionViewCell"
     
+    var isClickedClosure: ((_ section: Int, _ index: Int) -> Void)?
+    var section: Int?
+    
     // MARK: - UI Components
     
     lazy var nestedCollectionView = NestedView(frame: .zero)
@@ -51,6 +54,11 @@ extension RecommendCollectionViewCell {
     private func setLayout() {
         addSubviews(nestedCollectionView)
         nestedCollectionView.item = item
+        if let section = section
+           {
+            nestedCollectionView.dataBind(section: section)
+            nestedCollectionView.isClickedClosure = isClickedClosure
+        }
         nestedCollectionView.config()
         
         nestedCollectionView.snp.makeConstraints {
@@ -58,5 +66,12 @@ extension RecommendCollectionViewCell {
             $0.directionalHorizontalEdges.equalToSuperview().inset(20.adjusted)
             $0.bottom.equalToSuperview()
         }
+    }
+    
+    func dataBind(section: Int) {
+        self.section = section
+        nestedCollectionView.section = section
+        nestedCollectionView.isClickedClosure = isClickedClosure
+        
     }
 }

--- a/NotToDo/NotToDo/Presentation/RecommendScene/ViewControllers/RecommendViewController.swift
+++ b/NotToDo/NotToDo/Presentation/RecommendScene/ViewControllers/RecommendViewController.swift
@@ -24,6 +24,8 @@ class RecommendViewController: UIViewController, CustomTabBarDelegate {
     typealias Item = AnyHashable
     var dataSource: UICollectionViewDiffableDataSource<Section, Item>! = nil
     
+    var isClickedClosure: ((_ section: Int, _ index: Int) -> Void)?
+  
     // MARK: - UI Components
     
     private var underLineView = UIView()
@@ -88,7 +90,7 @@ extension RecommendViewController {
         
         customTabBar.snp.makeConstraints {
             $0.directionalHorizontalEdges.equalToSuperview()
-            $0.top.equalTo(navigationBarView.snp.bottom).offset(19.adjusted)
+            $0.top.equalTo(navigationBarView.snp.bottom)
             $0.height.equalTo(104.adjusted)
         }
         
@@ -137,6 +139,10 @@ extension RecommendViewController {
             case .main:
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecommendCollectionViewCell.identifier, for: indexPath) as! RecommendCollectionViewCell
                 cell.item = self.itemList[indexPath.item]
+                cell.dataBind(section: indexPath.item)
+                cell.isClickedClosure = { [weak self] section, index in
+                    self?.pushToAdd(section: section, index: index)
+                }
                 cell.config()
                 return cell
             }
@@ -190,6 +196,13 @@ extension RecommendViewController {
         let group = NSCollectionLayoutGroup.vertical(layoutSize: .init(widthDimension: .fractionalWidth(1), heightDimension: .estimated(200)), subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         return section
+    }
+    
+    private func pushToAdd(section: Int, index: Int) {
+        let addMissionViewController = AddMissionViewController()
+        addMissionViewController.behavior = itemList[section].recommendActions[index].name
+        addMissionViewController.modalPresentationStyle = .fullScreen
+        self.present(addMissionViewController, animated: false, completion: nil)
     }
     
     // MARK: - @objc Methods

--- a/NotToDo/NotToDo/Presentation/RecommendScene/ViewControllers/RecommendViewController.swift
+++ b/NotToDo/NotToDo/Presentation/RecommendScene/ViewControllers/RecommendViewController.swift
@@ -14,7 +14,7 @@ class RecommendViewController: UIViewController, CustomTabBarDelegate {
     
     // MARK: - Properties
     
-    var navigationBarView = NavigationBarView(frame: CGRect(), mode: .leftRecommend) // .leftRecommend
+    var navigationBarView = NavigationBarView(frame: CGRect(), mode: .leftRecommend) 
     var itemList: [RecommendElementResponse] = []
     var selectedIndex: Int = 0
     
@@ -69,9 +69,6 @@ extension RecommendViewController {
         customTabBar.delegate = self
         
         navigationBarView.backButton.addTarget(self, action: #selector(popToAddMissionController), for: .touchUpInside)
-        nestedView.do {
-            $0.collectionview.delegate = self
-        }
     }
     
     private func register() {
@@ -201,8 +198,11 @@ extension RecommendViewController {
     private func pushToAdd(section: Int, index: Int) {
         let addMissionViewController = AddMissionViewController()
         addMissionViewController.behavior = itemList[section].recommendActions[index].name
-        addMissionViewController.modalPresentationStyle = .fullScreen
-        self.present(addMissionViewController, animated: false, completion: nil)
+        addMissionViewController.addMissionView?.navigationBarView = NavigationBarView(frame: CGRect(), mode: .addSituation)
+        let navigationController = UINavigationController(rootViewController: addMissionViewController)
+        navigationController.modalPresentationStyle = .overFullScreen
+        navigationController.isNavigationBarHidden = true
+        self.present(navigationController, animated: false)
     }
     
     // MARK: - @objc Methods
@@ -215,12 +215,5 @@ extension RecommendViewController {
     
     @objc private func popToAddMissionController() {
         self.navigationController?.popViewController(animated: true)
-    }
-}
-extension RecommendViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let addMissionViewController = AddMissionViewController()
-        addMissionViewController.modalPresentationStyle = .fullScreen
-        present(addMissionViewController, animated: false, completion: nil)
     }
 }

--- a/NotToDo/NotToDo/Presentation/RecommendScene/Views/NestedView.swift
+++ b/NotToDo/NotToDo/Presentation/RecommendScene/Views/NestedView.swift
@@ -16,6 +16,10 @@ class NestedView: UIView {
 
     var item: RecommendElementResponse?
     
+    var isClickedClosure: ((_ section: Int, _ index: Int) -> Void)?
+    var section: Int?
+    var index: Int?
+    
     enum Section: Int, Hashable {
         case main
     }
@@ -49,12 +53,17 @@ extension NestedView {
         reloadData()
     }
     
+    func dataBind(section: Int) {
+        self.section = section
+    }
+    
     private func setUI() {
         collectionview.do {
             $0.backgroundColor = .clear
             $0.showsVerticalScrollIndicator = false
             $0.isScrollEnabled = false
             $0.bounces = false
+            $0.delegate = self
         }
     }
     
@@ -126,7 +135,9 @@ extension NestedView {
 }
 extension NestedView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
+        if let section = section {
+            isClickedClosure?(section, indexPath.item)
+        }
         print("tapped")
     }
 }


### PR DESCRIPTION
## 🫧 작업한 내용

- 성취뷰 오류 수정
- 추천뷰 플로우 수정 

## 👻 PR Point

추천뷰에서  cell을 선택했을 때 선택된 셀의 label이 추가하기 textfield로 옮겨지도록 했습니다.
성취뷰에서 empty로 넘어와서 뷰가 뜨지 않는 부분을 수정했습니다.
통계보기 bottom label의 위치 수정했습니다.
탭바에서 뜨는 추천뷰와 추가하기에서 뜨는 추천뷰의 헤더 부분이 달라서 분기처리를 통해서 해결했습니다.

## 📸 스크린샷

![Jan-13-2023 03-57-14](https://user-images.githubusercontent.com/107853954/212156956-33959ad2-9804-4e93-aa82-cf7e39a57ff2.gif)


## 📮 관련 이슈


- Resolved: #66
