### PR TITLE
[FEAT] #76 - 낫투두를 다른 날짜에도 추가 API 연결

### DIFF
--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		3B16287D295AD7870077AE7B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B16287C295AD7870077AE7B /* Assets.xcassets */; };
 		3B162880295AD7870077AE7B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B16287E295AD7870077AE7B /* LaunchScreen.storyboard */; };
 		3B1628B9295ADD750077AE7B /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1628B8295ADD750077AE7B /* Colors.xcassets */; };
+		3B2748632970B570005DBD46 /* AddAnotherDayResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */; };
 		3B3405B7295B05D400D44722 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405B6295B05D400D44722 /* .swiftlint.yml */; };
 		3B3405BC295B0A2400D44722 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405BB295B0A2400D44722 /* Pretendard-Bold.otf */; };
 		3B3405BE295B0A8200D44722 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405BD295B0A8200D44722 /* Pretendard-Medium.otf */; };
@@ -192,6 +193,7 @@
 		3B1628B1295ADB710077AE7B /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		3B1628B3295ADBA20077AE7B /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		3B1628B8295ADD750077AE7B /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAnotherDayResponseDTO.swift; sourceTree = "<group>"; };
 		3B3405B6295B05D400D44722 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3B3405B8295B090300D44722 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		3B3405BB295B0A2400D44722 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 				3B90A431296F2981000D6852 /* BannerResponseDTO.swift */,
 				3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */,
 				3BFE8412297071BB000B37CA /* UpdateMissionResponseDTO.swift */,
+				3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1265,6 +1268,7 @@
 				3BBE56F3296C4EB000771DE4 /* SecondOnboardingViewController.swift in Sources */,
 				096BDFD92964FEF6009ED396 /* CustomCalendarView.swift in Sources */,
 				099F072A296B98B90036CF55 /* SituationTitleView.swift in Sources */,
+				3B2748632970B570005DBD46 /* AddAnotherDayResponseDTO.swift in Sources */,
 				3B4B90BD2965673E008C5CA8 /* AuthViewController.swift in Sources */,
 				09D3C538296FFD7C00F1488D /* SituationStatisticsAPI.swift in Sources */,
 				099F0724296AA4A40036CF55 /* TitleView.swift in Sources */,

--- a/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
@@ -18,6 +18,7 @@ final class HomeAPI {
     
     public private(set) var missionDailyData: GeneralArrayResponse<DailyMissionResponseDTO>?
     public private(set) var updateMissionStatus: GeneralResponse<UpdateMissionResponseDTO>?
+    public private(set) var addAnotherDay: GeneralResponse<AddAnotherDayResponseDTO>?
 
     // MARK: - GET
         
@@ -87,5 +88,24 @@ final class HomeAPI {
             }
         }
     }
-
+    
+    // MARK: - Post
+    
+    func postAnotherDay(id: Int, dates: [String], completion: @escaping (GeneralResponse<AddAnotherDayResponseDTO>?) -> Void) {
+        homeProvider.request(.addAnotherDay(id: id, dates: dates)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.addAnotherDay = try response.map(GeneralResponse<AddAnotherDayResponseDTO>?.self)
+                    guard let addAnotherDay = self.addAnotherDay else { return }
+                    completion(addAnotherDay)
+                } catch(let err) {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
 }

--- a/NotToDo/NotToDo/Network/DataModel/Home/AddAnotherDayResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/AddAnotherDayResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  AddAnotherDayResponseDTO.swift
+//  NotToDo
+//
+//  Created by 강윤서 on 2023/01/13.
+//
+
+import Foundation
+
+struct AddAnotherDayResponseDTO: Codable {
+    let dates: [String]?
+}

--- a/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
+++ b/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
@@ -14,6 +14,7 @@ enum HomeService {
     case dailyMission(date: String)
     case updateMissionStatus(id: Int, status: String)
     case deleteMission(id: Int)
+    case addAnotherDay(id: Int, dates: [String])
 }
 
 extension HomeService: TargetType {
@@ -29,7 +30,7 @@ extension HomeService: TargetType {
             return URLConstant.dailyMission + "/\(date)"
         case .updateMissionStatus(let id, _):
             return URLConstant.mission + "/\(id)" + "/check"
-        case .deleteMission(let id):
+        case .deleteMission(let id), .addAnotherDay(let id, _):
             return URLConstant.mission + "/\(id)"
         }
     }
@@ -42,6 +43,8 @@ extension HomeService: TargetType {
             return .patch
         case .deleteMission:
             return .delete
+        case .addAnotherDay:
+            return .post
         }
     }
     
@@ -52,12 +55,15 @@ extension HomeService: TargetType {
         case .updateMissionStatus(_, let status):
             return .requestParameters(parameters: ["completionStatus": status],
                                       encoding: JSONEncoding.default)
+        case .addAnotherDay(_, let dates):
+            return .requestParameters(parameters: ["dates": dates],
+                                      encoding: JSONEncoding.default)
         }
     }
     
     var headers: [String: String]? {
         switch self {
-        case .banner, .dailyMission, .updateMissionStatus, .deleteMission:
+        case .banner, .dailyMission, .updateMissionStatus, .deleteMission, .addAnotherDay:
             return NetworkConstant.hasTokenHeader
         }
     }

--- a/NotToDo/NotToDo/Presentation/Common/ActionSheet/ActionSheetViewController.swift
+++ b/NotToDo/NotToDo/Presentation/Common/ActionSheet/ActionSheetViewController.swift
@@ -101,8 +101,15 @@ extension ActionSheetViewController {
     
     private func requestDeleteMission(id: Int) {
         HomeAPI.shared.deleteMission(id: id) { [weak self] response in
-            guard let self = self else { return }
-            guard let response = response else { return }
+            guard self != nil else { return }
+            guard response != nil else { return }
+        }
+    }
+    
+    private func requestAddAnotherDay(id: Int, dates: [String]) {
+        HomeAPI.shared.postAnotherDay(id: id, dates: dates) { [weak self] response in
+            guard self != nil else { return }
+            guard response != nil else { return }
         }
     }
     
@@ -121,6 +128,7 @@ extension ActionSheetViewController {
     }
     
     @objc private func choiceFinishButtonDidTap() {
+        requestAddAnotherDay(id: id, dates: ["2023.01.26", "2032.01.26"])
         dismissActionSheetWithAnimation()
     }
 }

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -55,7 +55,6 @@ extension HomeViewController: CheckboxToolTipDelegate {
 extension HomeViewController: ActionSheetViewDelegate {
     func reloadMissionData() {
         requestDailyMissionAPI(date: "2023-01-25")
-        print(missionList, "☘️")
         homeView.homeCollectionView.reloadData()
     }
 }

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -172,6 +172,7 @@ extension HomeViewController: UICollectionViewDataSource {
                     actionSheetViewController.dismissClicked = {
                         let calendarActionSheetViewController = ActionSheetViewController()
                         calendarActionSheetViewController.mode = .calendar
+                        calendarActionSheetViewController.id = missionId
                         calendarActionSheetViewController.modalPresentationStyle = .overFullScreen
                         calendarActionSheetViewController.modalTransitionStyle = .crossDissolve
                         self?.present(calendarActionSheetViewController, animated: true)


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 낫투두를 다른 날짜에도 추가 API를 연결했습니다.

## 👻 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 삭제하기, 추가하기와 마찬가지로 날짜 배열은 더미 값으로 넣어둔 상태입니다.
- 삭제하기, 추가하기와 마찬가지로 reload가 즉시 되지 않습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   낫투두를 다른 날짜에도 추가 API 연결     |<img src = "https://user-images.githubusercontent.com/65678579/212191436-7beb9aa2-1d06-4d4e-bf52-23b22720af3b.png" width ="475">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #76
