### PR TITLE
[FEAT] #78 - 주별 낫투두 조회 API 연결

### DIFF
--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		3B162880295AD7870077AE7B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3B16287E295AD7870077AE7B /* LaunchScreen.storyboard */; };
 		3B1628B9295ADD750077AE7B /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B1628B8295ADD750077AE7B /* Colors.xcassets */; };
 		3B2748632970B570005DBD46 /* AddAnotherDayResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */; };
+		3B2748672970C361005DBD46 /* MissionWeeklyResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2748662970C361005DBD46 /* MissionWeeklyResponseDTO.swift */; };
 		3B3405B7295B05D400D44722 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405B6295B05D400D44722 /* .swiftlint.yml */; };
 		3B3405BC295B0A2400D44722 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405BB295B0A2400D44722 /* Pretendard-Bold.otf */; };
 		3B3405BE295B0A8200D44722 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3B3405BD295B0A8200D44722 /* Pretendard-Medium.otf */; };
@@ -194,6 +195,7 @@
 		3B1628B3295ADBA20077AE7B /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		3B1628B8295ADD750077AE7B /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAnotherDayResponseDTO.swift; sourceTree = "<group>"; };
+		3B2748662970C361005DBD46 /* MissionWeeklyResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionWeeklyResponseDTO.swift; sourceTree = "<group>"; };
 		3B3405B6295B05D400D44722 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		3B3405B8295B090300D44722 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		3B3405BB295B0A2400D44722 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
@@ -834,6 +836,7 @@
 				3BFE8410297059D7000B37CA /* DailyMissionResponseDTO.swift */,
 				3BFE8412297071BB000B37CA /* UpdateMissionResponseDTO.swift */,
 				3B2748622970B570005DBD46 /* AddAnotherDayResponseDTO.swift */,
+				3B2748662970C361005DBD46 /* MissionWeeklyResponseDTO.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1178,6 +1181,7 @@
 				3B42D1F02966A6320012898E /* myInfoFooterCollectionReusableView.swift in Sources */,
 				3BE0701B296F455C002CC50A /* HomeViewController.swift in Sources */,
 				3BFE8405296FD103000B37CA /* CheckboxToolTipViewController.swift in Sources */,
+				3B2748672970C361005DBD46 /* MissionWeeklyResponseDTO.swift in Sources */,
 				3BE07003296F43A2002CC50A /* UIFont+.swift in Sources */,
 				3B888AA729674BA4008209A8 /* RandomData.swift in Sources */,
 				096BDFF02965104B009ED396 /* MissionStatisticsView.swift in Sources */,

--- a/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
@@ -19,7 +19,7 @@ final class HomeAPI {
     public private(set) var missionDailyData: GeneralArrayResponse<DailyMissionResponseDTO>?
     public private(set) var updateMissionStatus: GeneralResponse<UpdateMissionResponseDTO>?
     public private(set) var addAnotherDay: GeneralResponse<AddAnotherDayResponseDTO>?
-    public private(set) var missionWeekly: GeneralResponse<MissionWeeklyResponseDTO>?
+    public private(set) var missionWeekly: GeneralResponse<WeekMissionResponseDTO>?
 
     // MARK: - GET
         
@@ -58,7 +58,7 @@ final class HomeAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = NetworkBase.judgeStatus(by: statusCode, data,
-                                                            MissionWeeklyResponseDTO.self)
+                                                            [WeekMissionResponseDTO].self)
                 completion(networkResult)
             case let .failure(err):
                 print(err)

--- a/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
+++ b/NotToDo/NotToDo/Network/API/Home/HomeAPI.swift
@@ -19,6 +19,7 @@ final class HomeAPI {
     public private(set) var missionDailyData: GeneralArrayResponse<DailyMissionResponseDTO>?
     public private(set) var updateMissionStatus: GeneralResponse<UpdateMissionResponseDTO>?
     public private(set) var addAnotherDay: GeneralResponse<AddAnotherDayResponseDTO>?
+    public private(set) var missionWeekly: GeneralResponse<MissionWeeklyResponseDTO>?
 
     // MARK: - GET
         
@@ -43,6 +44,21 @@ final class HomeAPI {
                 let statusCode = response.statusCode
                 let data = response.data
                 let networkResult = NetworkBase.judgeStatus(by: statusCode, data, [DailyMissionResponseDTO].self)
+                completion(networkResult)
+            case let .failure(err):
+                print(err)
+            }
+        }
+    }
+
+    func getWeeklyMissoin(startDate: String, completion: @escaping (NetworkResult<Any>) -> Void) {
+        homeProvider.request(.missionWeekly(startDate: startDate)) { response in
+            switch response {
+            case let .success(response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = NetworkBase.judgeStatus(by: statusCode, data,
+                                                            MissionWeeklyResponseDTO.self)
                 completion(networkResult)
             case let .failure(err):
                 print(err)

--- a/NotToDo/NotToDo/Network/Base/URLConstant.swift
+++ b/NotToDo/NotToDo/Network/Base/URLConstant.swift
@@ -18,6 +18,7 @@ struct URLConstant {
     static let homeBanner = "/banner"
     static let dailyMission = "/mission/daily"
     static let mission = "/mission"
+    static let missionWeekly = "/mission/week"
     
     // MARK: - Recommend
     

--- a/NotToDo/NotToDo/Network/DataModel/Home/MissionWeeklyResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/MissionWeeklyResponseDTO.swift
@@ -7,11 +7,7 @@
 
 import Foundation
 
-struct MissionWeeklyResponseDTO: Codable {
-    let data: [WeekMission]
-}
-
-struct WeekMission: Codable {
+struct WeekMissionResponseDTO: Codable {
     let actionDate: String
-    let percentage: Float
+    let percentage: CGFloat
 }

--- a/NotToDo/NotToDo/Network/DataModel/Home/MissionWeeklyResponseDTO.swift
+++ b/NotToDo/NotToDo/Network/DataModel/Home/MissionWeeklyResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  MissionWeeklyResponseDTO.swift
+//  NotToDo
+//
+//  Created by 강윤서 on 2023/01/13.
+//
+
+import Foundation
+
+struct MissionWeeklyResponseDTO: Codable {
+    let data: [WeekMission]
+}
+
+struct WeekMission: Codable {
+    let actionDate: String
+    let percentage: Float
+}

--- a/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
+++ b/NotToDo/NotToDo/Network/Service/Home/HomeService.swift
@@ -15,6 +15,7 @@ enum HomeService {
     case updateMissionStatus(id: Int, status: String)
     case deleteMission(id: Int)
     case addAnotherDay(id: Int, dates: [String])
+    case missionWeekly(startDate: String)
 }
 
 extension HomeService: TargetType {
@@ -32,12 +33,14 @@ extension HomeService: TargetType {
             return URLConstant.mission + "/\(id)" + "/check"
         case .deleteMission(let id), .addAnotherDay(let id, _):
             return URLConstant.mission + "/\(id)"
+        case .missionWeekly(let startDate):
+            return URLConstant.missionWeekly + "/\(startDate)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .banner, .dailyMission:
+        case .banner, .dailyMission, .missionWeekly:
             return .get
         case .updateMissionStatus:
             return .patch
@@ -50,7 +53,7 @@ extension HomeService: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .banner, .dailyMission, .deleteMission:
+        case .banner, .dailyMission, .deleteMission, .missionWeekly:
             return .requestPlain
         case .updateMissionStatus(_, let status):
             return .requestParameters(parameters: ["completionStatus": status],
@@ -62,9 +65,6 @@ extension HomeService: TargetType {
     }
     
     var headers: [String: String]? {
-        switch self {
-        case .banner, .dailyMission, .updateMissionStatus, .deleteMission, .addAnotherDay:
-            return NetworkConstant.hasTokenHeader
-        }
+        return NetworkConstant.hasTokenHeader
     }
 }

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -40,9 +40,9 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         requestBannerAPI()
+        requestWeeklyMissoinAPI(startDate: "2023-01-23")
         requestDailyMissionAPI(date: "2023-01-25")
     }
-    
 }
 
 extension HomeViewController: CheckboxToolTipDelegate {
@@ -54,6 +54,7 @@ extension HomeViewController: CheckboxToolTipDelegate {
 
 extension HomeViewController: ActionSheetViewDelegate {
     func reloadMissionData() {
+        requestWeeklyMissoinAPI(startDate: "2023-01-23")
         requestDailyMissionAPI(date: "2023-01-25")
         homeView.homeCollectionView.reloadData()
     }
@@ -107,6 +108,24 @@ extension HomeViewController: UICollectionViewDelegate {
             case .networkFail:
                 print("networkFail")
             case .requestErr(_):
+                print("networkFail")
+            }
+        }
+    }
+    
+    private func requestWeeklyMissoinAPI(startDate: String) {
+        HomeAPI.shared.getWeeklyMissoin(startDate: startDate) { result in
+            switch result {
+            case let .success(data):
+                guard let data = data as? [WeekMissionResponseDTO] else { return }
+                
+            case .requestErr(_):
+                print("requestErr")
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
                 print("networkFail")
             }
         }


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 주별 낫투두 조회 API를 연결했습니다.

## 👻 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 퍼센트에 따라 배경색을 달력에 반영하는 부분은 구현하지 않았습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|    주별 낫투두 조회 API 연결  | <img width="732" alt="image" src="https://user-images.githubusercontent.com/65678579/212237668-ac49c917-151b-4917-b6c1-9926f71d7932.png">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #78
