### PR TITLE
[FEAT] #88 - 홈 뷰 헤더 텍스트 캘린더 값으로 변경

### DIFF
--- a/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeCollectionReusableView.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/Cells/HomeCollectionReusableView.swift
@@ -19,8 +19,7 @@ final class HomeCollectionReusableView: UICollectionReusableView {
     
     // MARK: - UI Components
     
-    private lazy var dateFormatter = DateFormatter()
-    private var dateLabel = UILabel()
+    var dateLabel = UILabel()
     private let dateView = UIView()
     private var motivationLabel = UILabel()
     private var graphicImageView = UIImageView()
@@ -42,15 +41,10 @@ final class HomeCollectionReusableView: UICollectionReusableView {
 extension HomeCollectionReusableView {
     private func setUI() {
         backgroundColor = .nottodoWhite
-        dateFormatter.do {
-            $0.locale = Locale(identifier: "ko_KR")
-            $0.dateFormat = "YYYY년 M월"
-            $0.timeZone = TimeZone(identifier: "KST")
-        }
         dateLabel.do {
             $0.textColor = .nottodoBlack
             $0.font = .PretendardBold(size: 18.adjusted)
-            $0.text = "2023년 1월"            // dateFormatter로 수정
+//            $0.text = "2023년 1월"            // dateFormatter로 수정
         }
         dateView.backgroundColor = .yellow_basic
         motivationLabel.do {

--- a/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/ViewControllers/HomeViewController.swift
@@ -19,7 +19,9 @@ final class HomeViewController: UIViewController {
     var banner: BannerResponseDTO?
     var missionId: Int?
     private var clickedDay: String?
-    private let dateFormatter = DateFormatter()
+    private let todayDateFormatter = DateFormatter()
+    private let mothlyDateFormatter = DateFormatter()
+    private var currentPage: Date? = Date()
     
     // MARK: - UI Components
     
@@ -44,7 +46,7 @@ final class HomeViewController: UIViewController {
         super.viewWillAppear(animated)
         requestBannerAPI()
         requestWeeklyMissoinAPI(startDate: "2023-01-23")
-        requestDailyMissionAPI(date: "2023-01-25")
+        requestDailyMissionAPI(date: clickedDay ?? "")
     }
 }
 
@@ -73,9 +75,14 @@ extension HomeViewController: UICollectionViewDelegate {
                                           for: .valueChanged)
         }
         
-        dateFormatter.do {
+        todayDateFormatter.do {
             $0.locale = Locale(identifier: "ko_KR")
             $0.dateFormat = "yyyy-MM-dd"
+        }
+        
+        mothlyDateFormatter.do {
+            $0.locale = Locale(identifier: "ko_KR")
+            $0.dateFormat = "yyyy년 M월"
         }
     }
     
@@ -152,7 +159,7 @@ extension HomeViewController: UICollectionViewDelegate {
     @objc func handleRefreshControl() {
         // 컨텐츠를 업데이트하세요.
         requestBannerAPI()
-        requestDailyMissionAPI(date: "2023-01-25")
+        requestDailyMissionAPI(date: clickedDay ?? "")
         homeView.homeCollectionView.reloadData()
         
         DispatchQueue.main.async {
@@ -171,6 +178,7 @@ extension HomeViewController: UICollectionViewDataSource {
         case 0:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCalendarCollectionViewCell.identifier, for: indexPath) as? HomeCalendarCollectionViewCell else { return UICollectionViewCell() }
             cell.calendar.delegate = self
+            self.currentPage = cell.calendar.currentPage
             return cell
         default:
             if missionList.isEmpty {
@@ -233,6 +241,7 @@ extension HomeViewController: UICollectionViewDataSource {
                 withReuseIdentifier: HomeCollectionReusableView.identifier,
                 for: indexPath
               ) as? HomeCollectionReusableView else { return UICollectionReusableView() }
+        header.dateLabel.text = mothlyDateFormatter.string(from: self.currentPage ?? Date())
         if let banner = banner {
             header.setRandomData(banner: banner)
         }
@@ -284,7 +293,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
 
 extension HomeViewController: FSCalendarDelegate {
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-        clickedDay = dateFormatter.string(from: date)
+        clickedDay = todayDateFormatter.string(from: date)
         requestDailyMissionAPI(date: clickedDay ?? "")
     }
 }

--- a/NotToDo/NotToDo/Presentation/HomeScene/Views/HomeView.swift
+++ b/NotToDo/NotToDo/Presentation/HomeScene/Views/HomeView.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-import FSCalendar
 import SnapKit
 import Then
 
@@ -9,7 +8,6 @@ final class HomeView: UIView {
     // MARK: - UI Components
     
     lazy var homeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
-    var calendar = FSCalendar(frame: .zero)
     let addMissionButton = NotTodoButton(frame: CGRect(), mode: .withImage, text: I18N.addMissoinButton, image: .plus, font: .semiBold, size: 16)
     
     // MARK: - Life Cycle


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 홈 뷰 헤더 텍스트 캘린더 값으로 변경

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
![Simulator Screen Recording - iPhone 13 Pro - 2023-01-13 at 16 51 23](

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   홈 뷰 헤더 주별 캘린더 값으로 변경     |<img src = "https://user-images.githubusercontent.com/65678579/212266821-1bd592d8-3e0b-4c2b-b93f-ae0474e22869.gif" width ="375">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #88
