### PR TITLE
[FEAT] #99 - 검색 기록 뷰 키보드 완료 버튼으로 뷰 이동

### DIFF
--- a/NotToDo/NotToDo/Presentation/MissionHistoryScene/ViewControllers/MissionHistoryViewController.swift
+++ b/NotToDo/NotToDo/Presentation/MissionHistoryScene/ViewControllers/MissionHistoryViewController.swift
@@ -45,7 +45,8 @@ extension MissionHistoryViewController {
     }
     
     private func setAddTarget() {
-        missionHistoryView.backButton.addTarget(self, action: #selector(popToAddMissionViewController), for: .touchUpInside)
+        missionHistoryView.inputTextField.keyboardToolbar.doneBarButton.setTarget(self, action: #selector(popToAddMissionViewController))
+        missionHistoryView.backButton.addTarget(self, action: #selector(cancelMissionHistory), for: .touchUpInside)
     }
     
     private func requestMissionHistoryAPI() {
@@ -64,6 +65,10 @@ extension MissionHistoryViewController {
 
     @objc private func popToAddMissionViewController() {
         sendData()
+    }
+    
+    @objc private func cancelMissionHistory() {
+        self.navigationController?.popViewController(animated: true)
     }
     
     private func sendData() {


### PR DESCRIPTION
## 🫧 작업한 내용

검색 기록 뷰 키보드 완료 버튼으로 뷰 이동

## 👻 PR Point

키보드에서 완료 버튼 클릭 시 데이터를 전달하며 생성 뷰로 돌아갑니당
검색창 옆 취소 버튼 클릭 시 데이터를 전달하지 않고 생성 뷰로 돌아갑니당


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|  키보드 완료 버튼으로 뷰 이동 |<img src = "https://user-images.githubusercontent.com/83651335/212337059-d0d19b7e-b12f-4ec0-9d04-7f0063ee0131.gif" width ="250">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #99 
