### PR TITLE
[FEAT] 카카오 로그인 기능 구현

### DIFF
--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -138,6 +138,16 @@
 		6CA38696296A82B10049D28A /* AddSituationFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA38695296A82B10049D28A /* AddSituationFooterView.swift */; };
 		6CC79FF9296C63B000A29DFE /* AddBehaviorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC79FF8296C63B000A29DFE /* AddBehaviorCollectionViewCell.swift */; };
 		6CC79FFC296C64AD00A29DFE /* AddBehaviorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC79FFB296C64AD00A29DFE /* AddBehaviorModel.swift */; };
+		6CCA66EF2992101D00B59394 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66EE2992101D00B59394 /* KakaoSDK */; };
+		6CCA66F12992101D00B59394 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66F02992101D00B59394 /* KakaoSDKAuth */; };
+		6CCA66F32992101D00B59394 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66F22992101D00B59394 /* KakaoSDKCommon */; };
+		6CCA66F52992101D00B59394 /* KakaoSDKCommonCore in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66F42992101D00B59394 /* KakaoSDKCommonCore */; };
+		6CCA66F72992101D00B59394 /* KakaoSDKNavi in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66F62992101D00B59394 /* KakaoSDKNavi */; };
+		6CCA66F92992101D00B59394 /* KakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66F82992101D00B59394 /* KakaoSDKShare */; };
+		6CCA66FB2992101D00B59394 /* KakaoSDKStory in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66FA2992101D00B59394 /* KakaoSDKStory */; };
+		6CCA66FD2992101D00B59394 /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66FC2992101D00B59394 /* KakaoSDKTalk */; };
+		6CCA66FF2992101D00B59394 /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA66FE2992101D00B59394 /* KakaoSDKTemplate */; };
+		6CCA67012992101D00B59394 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 6CCA67002992101D00B59394 /* KakaoSDKUser */; };
 		6CCBCF91297060550093C0F3 /* MissionHistoryAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF90297060550093C0F3 /* MissionHistoryAPI.swift */; };
 		6CCBCF93297061200093C0F3 /* MissionHistoryResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF92297061200093C0F3 /* MissionHistoryResponseDTO.swift */; };
 		6CCBCF95297075590093C0F3 /* AddMissionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF94297075590093C0F3 /* AddMissionAPI.swift */; };
@@ -277,6 +287,7 @@
 		6CA38695296A82B10049D28A /* AddSituationFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSituationFooterView.swift; sourceTree = "<group>"; };
 		6CC79FF8296C63B000A29DFE /* AddBehaviorCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBehaviorCollectionViewCell.swift; sourceTree = "<group>"; };
 		6CC79FFB296C64AD00A29DFE /* AddBehaviorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBehaviorModel.swift; sourceTree = "<group>"; };
+		6CCA67022992110C00B59394 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		6CCBCF90297060550093C0F3 /* MissionHistoryAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryAPI.swift; sourceTree = "<group>"; };
 		6CCBCF92297061200093C0F3 /* MissionHistoryResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionHistoryResponseDTO.swift; sourceTree = "<group>"; };
 		6CCBCF94297075590093C0F3 /* AddMissionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionAPI.swift; sourceTree = "<group>"; };
@@ -294,11 +305,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				3BFE840B29704534000B37CA /* Kingfisher in Frameworks */,
+				6CCA66FD2992101D00B59394 /* KakaoSDKTalk in Frameworks */,
 				3B4187D5296D5D8700F0FBF4 /* IQKeyboardManagerSwift in Frameworks */,
 				090FA2FB2960B87500918AED /* Moya in Frameworks */,
+				6CCA67012992101D00B59394 /* KakaoSDKUser in Frameworks */,
+				6CCA66F52992101D00B59394 /* KakaoSDKCommonCore in Frameworks */,
+				6CCA66FF2992101D00B59394 /* KakaoSDKTemplate in Frameworks */,
+				6CCA66F72992101D00B59394 /* KakaoSDKNavi in Frameworks */,
+				6CCA66F92992101D00B59394 /* KakaoSDKShare in Frameworks */,
 				096BDFD52960B910009ED396 /* FSCalendar in Frameworks */,
+				6CCA66FB2992101D00B59394 /* KakaoSDKStory in Frameworks */,
+				6CCA66F32992101D00B59394 /* KakaoSDKCommon in Frameworks */,
 				090FA2F82960B74000918AED /* Then in Frameworks */,
 				090FA2F52960B70400918AED /* SnapKit in Frameworks */,
+				6CCA66EF2992101D00B59394 /* KakaoSDK in Frameworks */,
+				6CCA66F12992101D00B59394 /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -718,6 +739,7 @@
 				3B1628B7295ADD6B0077AE7B /* Colors */,
 				3B1628B6295ADD640077AE7B /* Assets */,
 				3B162881295AD7870077AE7B /* Info.plist */,
+				6CCA67022992110C00B59394 /* Config.xcconfig */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -1071,6 +1093,16 @@
 				096BDFD42960B910009ED396 /* FSCalendar */,
 				3B4187D4296D5D8700F0FBF4 /* IQKeyboardManagerSwift */,
 				3BFE840A29704534000B37CA /* Kingfisher */,
+				6CCA66EE2992101D00B59394 /* KakaoSDK */,
+				6CCA66F02992101D00B59394 /* KakaoSDKAuth */,
+				6CCA66F22992101D00B59394 /* KakaoSDKCommon */,
+				6CCA66F42992101D00B59394 /* KakaoSDKCommonCore */,
+				6CCA66F62992101D00B59394 /* KakaoSDKNavi */,
+				6CCA66F82992101D00B59394 /* KakaoSDKShare */,
+				6CCA66FA2992101D00B59394 /* KakaoSDKStory */,
+				6CCA66FC2992101D00B59394 /* KakaoSDKTalk */,
+				6CCA66FE2992101D00B59394 /* KakaoSDKTemplate */,
+				6CCA67002992101D00B59394 /* KakaoSDKUser */,
 			);
 			productName = NotToDo;
 			productReference = 3B162870295AD7860077AE7B /* NotToDo.app */;
@@ -1107,6 +1139,7 @@
 				096BDFD32960B910009ED396 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				3B4187D3296D5D8700F0FBF4 /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
 				3BFE840929704534000B37CA /* XCRemoteSwiftPackageReference "Kingfisher" */,
+				6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = 3B162871295AD7860077AE7B /* Products */;
 			projectDirPath = "";
@@ -1308,6 +1341,7 @@
 /* Begin XCBuildConfiguration section */
 		3B162882295AD7870077AE7B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CCA67022992110C00B59394 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1368,6 +1402,7 @@
 		};
 		3B162883295AD7870077AE7B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CCA67022992110C00B59394 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1422,6 +1457,7 @@
 		};
 		3B162885295AD7870077AE7B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CCA67022992110C00B59394 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1435,6 +1471,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1452,6 +1489,7 @@
 		};
 		3B162886295AD7870077AE7B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6CCA67022992110C00B59394 /* Config.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1465,6 +1503,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1552,6 +1591,14 @@
 				kind = branch;
 			};
 		};
+		6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1584,6 +1631,56 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3BFE840929704534000B37CA /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		6CCA66EE2992101D00B59394 /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		6CCA66F02992101D00B59394 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		6CCA66F22992101D00B59394 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		6CCA66F42992101D00B59394 /* KakaoSDKCommonCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommonCore;
+		};
+		6CCA66F62992101D00B59394 /* KakaoSDKNavi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKNavi;
+		};
+		6CCA66F82992101D00B59394 /* KakaoSDKShare */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKShare;
+		};
+		6CCA66FA2992101D00B59394 /* KakaoSDKStory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKStory;
+		};
+		6CCA66FC2992101D00B59394 /* KakaoSDKTalk */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKTalk;
+		};
+		6CCA66FE2992101D00B59394 /* KakaoSDKTemplate */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKTemplate;
+		};
+		6CCA67002992101D00B59394 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6CCA66ED2992101D00B59394 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/NotToDo/NotToDo.xcodeproj/project.pbxproj
+++ b/NotToDo/NotToDo.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		6CCBCF95297075590093C0F3 /* AddMissionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF94297075590093C0F3 /* AddMissionAPI.swift */; };
 		6CCBCF9729707A790093C0F3 /* AddMissionReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF9629707A790093C0F3 /* AddMissionReqeustDTO.swift */; };
 		6CCBCF9929707AD80093C0F3 /* AddMissionResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCBCF9829707AD80093C0F3 /* AddMissionResponseDTO.swift */; };
+		6CCCD2C0299225E60065879B /* KakaoAuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCCD2BF299225E60065879B /* KakaoAuthModel.swift */; };
+		6CCCD2C42992265A0065879B /* KakaoAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCCD2C32992265A0065879B /* KakaoAuthViewController.swift */; };
+		6CCCD2C62992266B0065879B /* KakaoAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCCD2C52992266B0065879B /* KakaoAuthView.swift */; };
 		6CDC2D0C2963E2AF00BFF5F4 /* AddMissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDC2D0B2963E2AF00BFF5F4 /* AddMissionView.swift */; };
 		6CDC2D1529641BE000BFF5F4 /* AddMissionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDC2D1429641BE000BFF5F4 /* AddMissionTitleView.swift */; };
 		6CDC2D212966C86D00BFF5F4 /* AddMissionTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDC2D202966C86D00BFF5F4 /* AddMissionTextField.swift */; };
@@ -293,6 +296,9 @@
 		6CCBCF94297075590093C0F3 /* AddMissionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionAPI.swift; sourceTree = "<group>"; };
 		6CCBCF9629707A790093C0F3 /* AddMissionReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionReqeustDTO.swift; sourceTree = "<group>"; };
 		6CCBCF9829707AD80093C0F3 /* AddMissionResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionResponseDTO.swift; sourceTree = "<group>"; };
+		6CCCD2BF299225E60065879B /* KakaoAuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthModel.swift; sourceTree = "<group>"; };
+		6CCCD2C32992265A0065879B /* KakaoAuthViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthViewController.swift; sourceTree = "<group>"; };
+		6CCCD2C52992266B0065879B /* KakaoAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthView.swift; sourceTree = "<group>"; };
 		6CDC2D0B2963E2AF00BFF5F4 /* AddMissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionView.swift; sourceTree = "<group>"; };
 		6CDC2D1429641BE000BFF5F4 /* AddMissionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionTitleView.swift; sourceTree = "<group>"; };
 		6CDC2D202966C86D00BFF5F4 /* AddMissionTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddMissionTextField.swift; sourceTree = "<group>"; };
@@ -519,6 +525,7 @@
 				6C8826082967D30C0005E222 /* AddSituationScene */,
 				6C600BB729693A0300421D7A /* MissionHistoryScene */,
 				3B16289A295AD9850077AE7B /* AchievementScene */,
+				6CCCD2BD299225C20065879B /* KakaoAuthScene */,
 				3B16289B295AD9980077AE7B /* MyInfoScene */,
 				3B162897295AD95B0077AE7B /* TabBar */,
 			);
@@ -1051,6 +1058,40 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		6CCCD2BD299225C20065879B /* KakaoAuthScene */ = {
+			isa = PBXGroup;
+			children = (
+				6CCCD2BE299225D90065879B /* Models */,
+				6CCCD2C1299225F20065879B /* ViewControllers */,
+				6CCCD2C2299225FA0065879B /* Views */,
+			);
+			path = KakaoAuthScene;
+			sourceTree = "<group>";
+		};
+		6CCCD2BE299225D90065879B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				6CCCD2BF299225E60065879B /* KakaoAuthModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		6CCCD2C1299225F20065879B /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				6CCCD2C32992265A0065879B /* KakaoAuthViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		6CCCD2C2299225FA0065879B /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				6CCCD2C52992266B0065879B /* KakaoAuthView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		6CDC2D0A2963E2A100BFF5F4 /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -1244,6 +1285,8 @@
 				3BE07014296F44A2002CC50A /* TabBarController.swift in Sources */,
 				096BDFF7296522C6009ED396 /* CustomAchieveLabel.swift in Sources */,
 				3B90A42F296F293D000D6852 /* HomeAPI.swift in Sources */,
+				6CCCD2C42992265A0065879B /* KakaoAuthViewController.swift in Sources */,
+				6CCCD2C62992266B0065879B /* KakaoAuthView.swift in Sources */,
 				3BE0700A296F43A2002CC50A /* CALayer+.swift in Sources */,
 				3BBE56EB296C218D00771DE4 /* SecondOnboardingView.swift in Sources */,
 				3B90A432296F2981000D6852 /* BannerResponseDTO.swift in Sources */,
@@ -1282,6 +1325,7 @@
 				6CA2EFBE296FD28400D3E66B /* AddMissionService.swift in Sources */,
 				3BBE56F5296C4ED100771DE4 /* ThirdOnboardingViewController.swift in Sources */,
 				3BBE56E7296C214600771DE4 /* FirstOnboardingView.swift in Sources */,
+				6CCCD2C0299225E60065879B /* KakaoAuthModel.swift in Sources */,
 				09F695D9296C332D00877EA7 /* CompositionalLayout.swift in Sources */,
 				3B4B90C62965CB8D008C5CA8 /* myInfoUserCollectionViewCell.swift in Sources */,
 				09AF3FD229719DD900518D52 /* String+.swift in Sources */,

--- a/NotToDo/NotToDo/Application/AppDelegate.swift
+++ b/NotToDo/NotToDo/Application/AppDelegate.swift
@@ -8,14 +8,30 @@
 import UIKit
 
 import IQKeyboardManagerSwift
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        let nativeAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] ?? ""
+        
+        KakaoSDK.initSDK(appKey: nativeAppKey as! String)
+        
         IQKeyboardManager.shared.enable = true
+        
         return true
     }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                return AuthController.handleOpenUrl(url: url)
+            }
+
+            return false
+        }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         return UIInterfaceOrientationMask.portrait

--- a/NotToDo/NotToDo/Application/AppDelegate.swift
+++ b/NotToDo/NotToDo/Application/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        let nativeAppKey = Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] ?? ""
+        let nativeAppKey = "1fedb88d99f3002f423b7af1f7cbf8f2" // Bundle.main.infoDictionary?["KAKAO_NATIVE_APP_KEY"] ?? ""
         
         KakaoSDK.initSDK(appKey: nativeAppKey as! String)
         

--- a/NotToDo/NotToDo/Application/SceneDelegate.swift
+++ b/NotToDo/NotToDo/Application/SceneDelegate.swift
@@ -28,7 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
             
-            let rootViewController = OnboardingStartViewController()
+            let rootViewController = KakaoAuthViewController() // OnboardingStartViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/NotToDo/NotToDo/Application/SceneDelegate.swift
+++ b/NotToDo/NotToDo/Application/SceneDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 //import FirebaseCore
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -34,6 +36,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window = window
         }
     }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+            if let url = URLContexts.first?.url {
+                if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                    _ = AuthController.handleOpenUrl(url: url)
+                }
+            }
+        }
 
     func sceneDidDisconnect(_ scene: UIScene) {
     }

--- a/NotToDo/NotToDo/Application/SceneDelegate.swift
+++ b/NotToDo/NotToDo/Application/SceneDelegate.swift
@@ -28,7 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
             
-            let rootViewController = KakaoAuthViewController() // OnboardingStartViewController()
+            let rootViewController = OnboardingStartViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
@@ -6,3 +6,92 @@
 //
 
 import Foundation
+import Combine
+import KakaoSDKAuth
+import KakaoSDKUser
+
+class KakaoAuthModel: ObservableObject {
+    
+    var subscriptions = Set<AnyCancellable>()
+    
+    @Published var isLoggedIn: Bool = false
+    
+    init() {
+        print("KakaoAuthModel - init() called")
+    }
+    
+    // 카카오톡 앱으로 로그인
+    func kakaoLoginWithApp() async -> Bool {
+        
+        await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                    continuation.resume(returning: false)
+                } else {
+                    print("loginWithKakaoTalk() success.")
+                    
+                    // do something
+                    _ = oauthToken
+                    continuation.resume(returning: true)
+                }
+            }
+        }
+    }
+    
+    // 카카오 계정으로 로그인
+    func kakaoLoginWithAccocunt() async -> Bool {
+        
+        await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                    continuation.resume(returning: false)
+                } else {
+                    print("loginWithKakaoAccount() success.")
+                    
+                    // do something
+                    _ = oauthToken
+                    continuation.resume(returning: true)
+                }
+            }
+        }
+    }
+    
+    @MainActor
+    func KakaoLogin() {
+        print("KakaoAuthModel - handleKakaoLogin() called")
+        Task {
+            // 카카오톡 설치 여부 확인
+            if (UserApi.isKakaoTalkLoginAvailable()) {
+                isLoggedIn = await kakaoLoginWithApp()
+            } else { // 카톡 설치가 안 된 경우
+                isLoggedIn = await kakaoLoginWithAccocunt()
+            }
+        }
+    } // login
+    
+    @MainActor
+    func kakaoLogout() {
+        Task {
+            if await handleKakaoLogout() {
+                self.isLoggedIn = false
+            }
+        }
+    }
+    
+    func handleKakaoLogout() async -> Bool {
+        
+        await withCheckedContinuation() { continuation in
+            UserApi.shared.logout {(error) in
+                if let error = error {
+                    print(error)
+                    continuation.resume(returning: false)
+                } else {
+                    print("logout() success.")
+                    continuation.resume(returning: true)
+                }
+            }
+        }
+    }
+}

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import Combine
 import KakaoSDKAuth
 import KakaoSDKUser
+import UIKit
 
 class KakaoAuthModel: ObservableObject {
     
@@ -34,6 +35,9 @@ class KakaoAuthModel: ObservableObject {
                     // do something
                     _ = oauthToken
                     continuation.resume(returning: true)
+                    
+                    let accessToken = oauthToken?.accessToken
+                    self.setUserInfo()
                 }
             }
         }
@@ -53,6 +57,9 @@ class KakaoAuthModel: ObservableObject {
                     // do something
                     _ = oauthToken
                     continuation.resume(returning: true)
+                    
+                    let accessToken = oauthToken?.accessToken
+                    self.setUserInfo()
                 }
             }
         }
@@ -90,6 +97,27 @@ class KakaoAuthModel: ObservableObject {
                 } else {
                     print("logout() success.")
                     continuation.resume(returning: true)
+                }
+            }
+        }
+    }
+    
+    func setUserInfo() {
+        
+        UserApi.shared.me() {(user, error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("me() success.")
+                
+                // do something
+                _ = user
+                let nickname = user?.kakaoAccount?.profile?.nickname
+                print(user?.kakaoAccount?.profile?.nickname)
+                
+                if let url = user?.kakaoAccount?.profile?.profileImageUrl,
+                   let image = try? Data(contentsOf: url) {
+                    print(url)
                 }
             }
         }

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
@@ -17,9 +17,9 @@ class KakaoAuthModel: ObservableObject {
     
     @Published var isLoggedIn: Bool = false
     
-    init() {
-        print("KakaoAuthModel - init() called")
-    }
+//    init() {
+//        print("KakaoAuthModel - init() called")
+//    }
     
     // 카카오톡 앱으로 로그인
     func kakaoLoginWithApp() async -> Bool {
@@ -37,7 +37,6 @@ class KakaoAuthModel: ObservableObject {
                     continuation.resume(returning: true)
                     
                     let accessToken = oauthToken?.accessToken
-                    self.setUserInfo()
                 }
             }
         }
@@ -59,7 +58,6 @@ class KakaoAuthModel: ObservableObject {
                     continuation.resume(returning: true)
                     
                     let accessToken = oauthToken?.accessToken
-                    self.setUserInfo()
                 }
             }
         }
@@ -97,27 +95,6 @@ class KakaoAuthModel: ObservableObject {
                 } else {
                     print("logout() success.")
                     continuation.resume(returning: true)
-                }
-            }
-        }
-    }
-    
-    func setUserInfo() {
-        
-        UserApi.shared.me() {(user, error) in
-            if let error = error {
-                print(error)
-            } else {
-                print("me() success.")
-                
-                // do something
-                _ = user
-                let nickname = user?.kakaoAccount?.profile?.nickname
-                print(user?.kakaoAccount?.profile?.nickname)
-                
-                if let url = user?.kakaoAccount?.profile?.profileImageUrl,
-                   let image = try? Data(contentsOf: url) {
-                    print(url)
                 }
             }
         }

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Models/KakaoAuthModel.swift
@@ -1,0 +1,8 @@
+//
+//  KakaoAuthModel.swift
+//  NotToDo
+//
+//  Created by 김민서 on 2023/02/07.
+//
+
+import Foundation

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import KakaoSDKAuth
+import KakaoSDKUser
 
 final class KakaoAuthViewController: UIViewController {
     

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
@@ -5,4 +5,19 @@
 //  Created by 김민서 on 2023/02/07.
 //
 
-import Foundation
+import UIKit
+
+final class KakaoAuthViewController: UIViewController {
+    
+    // MARK: - UI Components
+    
+    var kakaoAuthView: KakaoAuthView!
+
+    // MARK: - Life View
+    
+    override func loadView() {
+        super.loadView()
+        kakaoAuthView = KakaoAuthView(frame: self.view.frame)
+        view = kakaoAuthView
+    }
+}

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/ViewControllers/KakaoAuthViewController.swift
@@ -1,0 +1,8 @@
+//
+//  KakaoAuthViewController.swift
+//  NotToDo
+//
+//  Created by 김민서 on 2023/02/07.
+//
+
+import Foundation

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
@@ -10,6 +10,7 @@ import UIKit
 import SnapKit
 import Then
 import Combine
+import KakaoSDKUser
 
 final class KakaoAuthView: UIView {
     
@@ -60,12 +61,14 @@ extension KakaoAuthView {
             $0.font = .PretendardBold(size: 20)
             $0.textColor = .nottodoGray1
             $0.textAlignment = .center
+            $0.text = I18N.login
             $0.numberOfLines = 0
         }
         
         loginStatusLabel.do {
             $0.font = .PretendardRegular(size: 12)
             $0.textColor = .nottodoGray1
+            $0.text = I18N.agreeLogin
         }
     }
     
@@ -122,11 +125,32 @@ extension KakaoAuthView {
     }
     
     fileprivate func setBindings() {
+        var nickname: String?
+        var imageUrl: Any?
+        
+        UserApi.shared.me() {(user, error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("me() success.")
+                
+                // do something
+                _ = user
+                
+               nickname = user?.kakaoAccount?.profile?.nickname
+                
+                if let url = user?.kakaoAccount?.profile?.profileImageUrl,
+                   let data = try? Data(contentsOf: url) {
+                    imageUrl = try? Data(contentsOf: url)
+                }
+            }
+        }
+        
         self.kakaoAuthModel.$isLoggedIn.sink { [weak self] isLoggedIn in
             guard let self = self else { return }
             self.loginStatusLabel.text = isLoggedIn ? "로그인 상태입니다." : "로그아웃 상태입니다."
-            self.loginImageView.image = isLoggedIn ? UIImage(data: image) : .login
             self.loginLabel.text = isLoggedIn ? nickname : I18N.login
+            self.loginImageView.image = isLoggedIn ? UIImage(data: imageUrl as! Data) : .login
         }
         .store(in: &subscriptions)
     }

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
@@ -16,8 +16,8 @@ final class KakaoAuthView: UIView {
     // MARK: - UI Components
     
     private var dismissButton = UIButton()
-    private var loginImageView = UIImageView()
-    private var loginLabel = UILabel()
+    var loginImageView = UIImageView()
+    var loginLabel = UILabel()
     private var kakaoLoginButton = UIButton()
     private var kakaoLogoutButton = UIButton()
     private var loginStatusLabel = UILabel()
@@ -43,7 +43,7 @@ extension KakaoAuthView {
     private func setUI() {
         backgroundColor = .nottodoWhite
         dismissButton.setBackgroundImage(.deletePageBtn, for: .normal)
-        loginImageView.image = .login
+        // loginImageView.image = .login
         kakaoLoginButton.do {
             $0.setBackgroundImage(.kakaoLoginButton, for: .normal)
             $0.addTarget(self, action: #selector(loginButtonClicked), for: .touchUpInside)
@@ -60,14 +60,12 @@ extension KakaoAuthView {
             $0.font = .PretendardBold(size: 20)
             $0.textColor = .nottodoGray1
             $0.textAlignment = .center
-            $0.text = I18N.login
             $0.numberOfLines = 0
         }
         
         loginStatusLabel.do {
             $0.font = .PretendardRegular(size: 12)
             $0.textColor = .nottodoGray1
-            $0.text = I18N.agreeLogin
         }
     }
     
@@ -127,6 +125,8 @@ extension KakaoAuthView {
         self.kakaoAuthModel.$isLoggedIn.sink { [weak self] isLoggedIn in
             guard let self = self else { return }
             self.loginStatusLabel.text = isLoggedIn ? "로그인 상태입니다." : "로그아웃 상태입니다."
+            self.loginImageView.image = isLoggedIn ? UIImage(data: image) : .login
+            self.loginLabel.text = isLoggedIn ? nickname : I18N.login
         }
         .store(in: &subscriptions)
     }

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
@@ -5,4 +5,129 @@
 //  Created by 김민서 on 2023/02/07.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+import Then
+import Combine
+
+final class KakaoAuthView: UIView {
+    
+    // MARK: - UI Components
+    
+    private var dismissButton = UIButton()
+    private var loginImageView = UIImageView()
+    private var loginLabel = UILabel()
+    private var kakaoLoginButton = UIButton()
+    private var kakaoLogoutButton = UIButton()
+    private var loginStatusLabel = UILabel()
+    lazy var kakaoAuthModel: KakaoAuthModel = { KakaoAuthModel() }()
+    var subscriptions = Set<AnyCancellable>()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+        setBindings()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension KakaoAuthView {
+    private func setUI() {
+        backgroundColor = .nottodoWhite
+        dismissButton.setBackgroundImage(.deletePageBtn, for: .normal)
+        loginImageView.image = .login
+        kakaoLoginButton.do {
+            $0.setBackgroundImage(.kakaoLoginButton, for: .normal)
+            $0.addTarget(self, action: #selector(loginButtonClicked), for: .touchUpInside)
+        }
+        
+        kakaoLogoutButton.do {
+            $0.setTitle("카카오 로그아웃", for: .normal)
+            $0.setTitleColor(.nottodoGray1, for: .normal)
+            $0.titleLabel?.font = .PretendardRegular(size: 14)
+            $0.addTarget(self, action: #selector(logoutButtonClicked), for: .touchUpInside)
+        }
+        
+        loginLabel.do {
+            $0.font = .PretendardBold(size: 20)
+            $0.textColor = .nottodoGray1
+            $0.textAlignment = .center
+            $0.text = I18N.login
+            $0.numberOfLines = 0
+        }
+        
+        loginStatusLabel.do {
+            $0.font = .PretendardRegular(size: 12)
+            $0.textColor = .nottodoGray1
+            $0.text = I18N.agreeLogin
+        }
+    }
+    
+    private func setLayout() {
+        addSubviews(dismissButton, loginImageView, kakaoLoginButton,
+                    kakaoLogoutButton, loginLabel, loginStatusLabel)
+        
+        dismissButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(75.adjusted)
+            $0.leading.equalToSuperview().inset(20.adjusted)
+            $0.size.equalTo(20.adjusted)
+        }
+        
+        loginImageView.snp.makeConstraints {
+            $0.top.equalTo(dismissButton.snp.bottom).offset(85.adjusted)
+            $0.centerX.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(121.adjusted)
+            $0.height.equalTo(216.adjusted)
+        }
+        
+        loginLabel.snp.makeConstraints {
+            $0.top.equalTo(loginImageView.snp.bottom).offset(39.adjusted)
+            $0.centerX.equalToSuperview()
+        }
+        
+        loginStatusLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(120.adjusted)
+        }
+        
+        kakaoLogoutButton.snp.makeConstraints {
+            $0.bottom.equalTo(loginStatusLabel.snp.top).offset(-17.adjusted)
+            $0.centerX.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(50.adjusted)
+        }
+        
+        kakaoLoginButton.snp.makeConstraints {
+            $0.bottom.equalTo(kakaoLogoutButton.snp.top).offset(-13.adjusted)
+            $0.centerX.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(50.adjusted)
+        }
+    }
+    
+    // MARK: - @objc Methods
+    
+    @objc func loginButtonClicked() {
+        print("login button clicked")
+        kakaoAuthModel.KakaoLogin()
+    }
+    
+    @objc func logoutButtonClicked() {
+        print("logout button clicked")
+        kakaoAuthModel.kakaoLogout()
+    }
+    
+    fileprivate func setBindings() {
+        self.kakaoAuthModel.$isLoggedIn.sink { [weak self] isLoggedIn in
+            guard let self = self else { return }
+            self.loginStatusLabel.text = isLoggedIn ? "로그인 상태입니다." : "로그아웃 상태입니다."
+        }
+        .store(in: &subscriptions)
+    }
+}

--- a/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
+++ b/NotToDo/NotToDo/Presentation/KakaoAuthScene/Views/KakaoAuthView.swift
@@ -1,0 +1,8 @@
+//
+//  KakaoAuthView.swift
+//  NotToDo
+//
+//  Created by 김민서 on 2023/02/07.
+//
+
+import Foundation

--- a/NotToDo/NotToDo/Resource/Config.xcconfig
+++ b/NotToDo/NotToDo/Resource/Config.xcconfig
@@ -1,0 +1,11 @@
+//
+//  Config.xcconfig
+//  NotToDo
+//
+//  Created by 김민서 on 2023/02/07.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+KAKAO_NATIVE_APP_KEY = 1fedb88d99f3002f423b7af1f7cbf8f2

--- a/NotToDo/NotToDo/Resource/Info.plist
+++ b/NotToDo/NotToDo/Resource/Info.plist
@@ -2,8 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>${KAKAO_NATVE_APP_KEY}</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao1fedb88d99f3002f423b7af1f7cbf8f2</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -28,5 +44,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 </dict>
 </plist>

--- a/NotToDo/NotToDo/Resource/Info.plist
+++ b/NotToDo/NotToDo/Resource/Info.plist
@@ -2,13 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>KAKAO_NATIVE_APP_KEY</key>
-	<string>${KAKAO_NATVE_APP_KEY}</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<false/>
-	</dict>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -16,10 +9,22 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakao1fedb88d99f3002f423b7af1f7cbf8f2</string>
+				<string>kakao${KAKAO_NATIVE_APP_KEY}</string>
 			</array>
 		</dict>
 	</array>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>${KAKAO_NATVE_APP_KEY}</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -44,10 +49,5 @@
 			</array>
 		</dict>
 	</dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 🫧 작업한 내용

* 카카오 로그인
* 로그인 후 닉네임 및 프로필 사진 띄우기
* 로그아웃

## 👻 PR Point

로그인 후 닉네임 및 프로필 사진을 띄우는 함수를 model에 넣고 싶었는데, 해당 정보를 뷰로 전달하는 게 잘 되지 않아 함수 자체를 일단 뷰에 구현했습니다. 이 부분을 어떻게 개선하면 좋을지 궁금합니닷


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   GIF           |<img src = "https://user-images.githubusercontent.com/83651335/218035090-b57c677b-b294-46ed-bba0-83fd6a881e2c.gif" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #104 
